### PR TITLE
Correct variable name for env during deployment

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -33,5 +33,5 @@ jobs:
 
       - name: Deploy application
         run: cf push --vars-file vars.yaml
-          --var ENVIRONMENT=${{ steps.cf-setup.outputs.target-environment }}
+          --var ENVIRONMENT_NAME=${{ steps.cf-setup.outputs.target-environment }}
           --strategy rolling


### PR DESCRIPTION
The deployment line in manifest.yaml uses `ENVIRONMENT_NAME` so it must be correct in the deployment action.