### PR TITLE
Add compatibility for multiple S3 services

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -30,10 +30,11 @@ jobs:
           cf-username: ${{ secrets.CF_USERNAME }}
           cf-password: ${{ secrets.CF_PASSWORD }}
           cf-org: ${{ secrets.CF_ORG }}
-          VENDOR_1: ${{ secrets.VENDOR_1 }}
-          VENDOR_2: ${{ secrets.VENDOR_2 }}
 
       - name: Deploy application
         run: cf push --vars-file vars.yaml
           --var ENVIRONMENT_NAME=${{ steps.cf-setup.outputs.target-environment }}
           --strategy rolling
+        with:
+          SERVICE_1: ${{ secrets.SERVICE_1 }}
+          SERVICE_2: ${{ secrets.SERVICE_2 }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -18,7 +18,7 @@ jobs:
     uses: 18F/identity-idva-s3-interface/.github/workflows/unit-tests.yaml@main
 
   deploy:
-    if: github.repository_owner == '18F'
+    if: github.repository_owner == 'GSA-TTS'
     needs: unit-test
     runs-on: ubuntu-latest
     steps:
@@ -30,6 +30,8 @@ jobs:
           cf-username: ${{ secrets.CF_USERNAME }}
           cf-password: ${{ secrets.CF_PASSWORD }}
           cf-org: ${{ secrets.CF_ORG }}
+          VENDOR_1: ${{ secrets.VENDOR_1 }}
+          VENDOR_2: ${{ secrets.VENDOR_2 }}
 
       - name: Deploy application
         run: cf push --vars-file vars.yaml

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -10,4 +10,5 @@ applications:
       - python_buildpack
     command: gunicorn s3.main:app
     services:
-      - sk-s3
+      - ((VENDOR_1))
+      - ((VENDOR_2))

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -10,5 +10,5 @@ applications:
       - python_buildpack
     command: gunicorn s3.main:app
     services:
-      - ((VENDOR_1))
-      - ((VENDOR_2))
+      - ((SERVICE_1))
+      - ((SERVICE_2))

--- a/s3/main.py
+++ b/s3/main.py
@@ -1,31 +1,36 @@
-import boto3
 import tempfile
 import mimetypes
 from flask import Flask, jsonify, request, send_file
 from s3 import s3_interface
 from s3 import settings
 
-s3 = boto3.resource(
-    "s3",
-    aws_access_key_id=settings.KEY_ID,
-    aws_secret_access_key=settings.SECRET_KEY,
-    region_name=settings.REGION,
-)
-bucket = s3.Bucket(settings.BUCKET)
+s3_clients = s3_interface.get_clients(settings.S3_CREDENTIALS)
 
 app = Flask(__name__)
 
 
-@app.route("/get", methods=["GET"])
-def get_file():
+@app.route("/get/<vendor_id>/<file_id>", methods=["GET"])
+def get_file(vendor_id, file_id):
     """
     Get file from s3 interface
     """
-    args = request.args
-    file_name = args.get("name")
+
+    if not settings.S3_CREDENTIALS[vendor_id]:
+        return (
+            jsonify(
+                {
+                    "error": "S3 Service not Found",
+                }
+            ),
+            404,
+        )
+
+    bucket = settings.S3_CREDENTIALS[vendor_id]["bucket"]
+    s3_client = s3_clients[vendor_id]
+
     tmp = tempfile.NamedTemporaryFile()
     try:
-        image = s3_interface.get_file(file_name, bucket, tmp)
+        image = s3_interface.get_file(s3_client, file_id, bucket, tmp)
     except FileNotFoundError:
         return (
             jsonify(
@@ -36,7 +41,7 @@ def get_file():
             404,
         )
     else:
-        return send_file(image, mimetype=mimetypes.guess_type(file_name)[0])
+        return send_file(image, mimetype=mimetypes.guess_type(file_id)[0])
 
 
 if __name__ == "__main__":

--- a/s3/main.py
+++ b/s3/main.py
@@ -9,13 +9,13 @@ s3_clients = s3_interface.get_clients(settings.S3_CREDENTIALS)
 app = Flask(__name__)
 
 
-@app.route("/get/<vendor_id>/", methods=["GET"])
-def get_file(vendor_id):
+@app.route("/get/<service_id>/", methods=["GET"])
+def get_file(service_id):
     """
     Get file from s3 interface
     """
 
-    if not vendor_id in settings.S3_CREDENTIALS:
+    if not service_id in settings.S3_CREDENTIALS:
         return (
             jsonify(
                 {
@@ -25,8 +25,8 @@ def get_file(vendor_id):
             404,
         )
 
-    bucket = settings.S3_CREDENTIALS[vendor_id]["bucket"]
-    s3_client = s3_clients[vendor_id]
+    bucket = settings.S3_CREDENTIALS[service_id]["bucket"]
+    s3_client = s3_clients[service_id]
 
     args = request.args
     file_name = args.get("file")

--- a/s3/main.py
+++ b/s3/main.py
@@ -9,13 +9,13 @@ s3_clients = s3_interface.get_clients(settings.S3_CREDENTIALS)
 app = Flask(__name__)
 
 
-@app.route("/get/<vendor_id>/<file_id>", methods=["GET"])
-def get_file(vendor_id, file_id):
+@app.route("/get/<vendor_id>/", methods=["GET"])
+def get_file(vendor_id):
     """
     Get file from s3 interface
     """
 
-    if not settings.S3_CREDENTIALS[vendor_id]:
+    if not vendor_id in settings.S3_CREDENTIALS:
         return (
             jsonify(
                 {
@@ -28,9 +28,12 @@ def get_file(vendor_id, file_id):
     bucket = settings.S3_CREDENTIALS[vendor_id]["bucket"]
     s3_client = s3_clients[vendor_id]
 
+    args = request.args
+    file_name = args.get("file")
+
     tmp = tempfile.NamedTemporaryFile()
     try:
-        image = s3_interface.get_file(s3_client, file_id, bucket, tmp)
+        image = s3_interface.get_file(s3_client, file_name, bucket, tmp)
     except FileNotFoundError:
         return (
             jsonify(
@@ -41,7 +44,7 @@ def get_file(vendor_id, file_id):
             404,
         )
     else:
-        return send_file(image, mimetype=mimetypes.guess_type(file_id)[0])
+        return send_file(image, mimetype=mimetypes.guess_type(file_name)[0])
 
 
 if __name__ == "__main__":

--- a/s3/s3_interface.py
+++ b/s3/s3_interface.py
@@ -1,4 +1,23 @@
-def get_file(key, bucket, tmp):
+import boto3
+
+
+def get_clients(s3_credentials):
+    """
+    creates list of boto3 s3 clients from list of s3 credentials
+    """
+    s3_clients = {}
+    for credentials in s3_credentials:
+        s3_client = boto3.client(
+            "s3",
+            aws_access_key_id=s3_credentials[credentials]["key_id"],
+            aws_secret_access_key=s3_credentials[credentials]["secret_key"],
+            region_name=s3_credentials[credentials]["region"],
+        )
+        s3_clients[credentials] = s3_client
+    return s3_clients
+
+
+def get_file(s3_client, key, bucket, tmp):
     """
     return specific file in base64 format from bucket to be stored in temp local file
     """
@@ -6,7 +25,7 @@ def get_file(key, bucket, tmp):
     # save file
     try:
         with open(tmp.name, "wb") as f:
-            bucket.download_fileobj(key, f)
+            s3_client.download_fileobj(bucket, key, f)
     except:
         raise FileNotFoundError
 

--- a/s3/settings.py
+++ b/s3/settings.py
@@ -11,20 +11,27 @@ log = logging.getLogger(__name__)
 def get_s3_info():
     vcap_services = os.getenv("VCAP_SERVICES")
     try:
-        credentials = json.loads(vcap_services)["s3"][0]["credentials"]
+        service_list = json.loads(vcap_services)["s3"]
     except (json.JSONDecodeError, KeyError) as err:
         log.warning("Unable to load info from VCAP_SERVICES")
         log.debug("Error: %s", str(err))
         raise Exception(str(err))
 
-    key_id = credentials["access_key_id"]
-    secret_key = credentials["secret_access_key"]
-    region = credentials["region"]
-    bucket = credentials["bucket"]
-    return (key_id, secret_key, region, bucket)
+    s3_credentials = {}
+
+    for service in service_list:
+        credentials = service["credentials"]
+        s3_credentials[service["name"]] = {
+            "key_id": credentials["access_key_id"],
+            "secret_key": credentials["secret_access_key"],
+            "region": credentials["region"],
+            "bucket": credentials["bucket"],
+        }
+
+    return s3_credentials
 
 
 PORT = int(os.getenv("PORT", 8080))
 HOST = "0.0.0.0"  # nosec
 
-KEY_ID, SECRET_KEY, REGION, BUCKET = get_s3_info()
+S3_CREDENTIALS = get_s3_info()

--- a/s3/tests/conftest.py
+++ b/s3/tests/conftest.py
@@ -7,7 +7,7 @@ from moto import mock_s3
 @pytest.fixture
 def s3_resource():
     with mock_s3():
-        s3 = boto3.resource(
+        s3 = boto3.client(
             "s3",
             aws_access_key_id="testing",
             aws_secret_access_key="testing",

--- a/s3/tests/test_get.py
+++ b/s3/tests/test_get.py
@@ -13,15 +13,15 @@ def bucket_name():
 @pytest.fixture
 def s3_test(s3_resource, bucket_name):
     s3_resource.create_bucket(Bucket=bucket_name)
-    s3_resource.Bucket(bucket_name).upload_file(
-        "./s3/tests/images/penguin.jpg", "penguin.jpg"
+    s3_resource.upload_file(
+        Filename="./s3/tests/images/penguin.jpg", Bucket=bucket_name, Key="penguin.jpg"
     )
 
 
 def test_get_image_pass(s3_resource, s3_test, bucket_name):
     tmp = tempfile.NamedTemporaryFile()
 
-    res = s3_interface.get_file("penguin.jpg", s3_resource.Bucket(bucket_name), tmp)
+    res = s3_interface.get_file(s3_resource, "penguin.jpg", bucket_name, tmp)
 
     with open("./s3/tests/images/penguin.jpg", "rb") as img:
         b64_og = base64.b64encode(img.read()).decode("utf-8")
@@ -35,7 +35,7 @@ def test_get_image_pass(s3_resource, s3_test, bucket_name):
 def test_get_image_not_found(s3_resource, s3_test, bucket_name):
     tmp = tempfile.NamedTemporaryFile()
     try:
-        s3_interface.get_file("does_not_exist", s3_resource.Bucket(bucket_name), tmp)
+        s3_interface.get_file(s3_resource, "does_not_exist", bucket_name, tmp)
     except FileNotFoundError:
         assert True
     else:


### PR DESCRIPTION
More S3 services require access via the IDVA platform and the s3-interface app can only interface to a single S3 service. This PR contains the following changes to adjust to new requirements:

- Check for multiple S3 services in settings
- Specific S3 service that is being accessed added to path parameter `/get/<service_id>
- Switch from boto3 resources to clients