### PR TITLE
Add delete endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ To set up your environment, run the following commands (or the equivalent
 commands if not using a bash-like terminal):
 ```shell
 # Clone the project
-git clone https://github.com/18F/identity-idva-s3-interface
+git clone https://github.com/GSA-TTS/identity-idva-s3-interface
 cd identity-idva-s3-interface
 
 # Set up Python virtual environment
@@ -41,8 +41,13 @@ pre-commit install
 After completing [development setup](#development-setup) application locally with:
 ```shell
 python -m pytest # NOTE that without DEBUG=True, local unit tests will fail
-uvicorn s3-interface.main:app
+gunicorn s3-interface.main:app
 ```
+
+### Available endpoints
+
+`GET` or `DELETE` `/<vendor_id>?file=<file_name>`
+
 
 ### Testing the application
 After completing [development setup](#development-setup) application locally with:

--- a/s3/main.py
+++ b/s3/main.py
@@ -9,8 +9,8 @@ s3_clients = s3_interface.get_clients(settings.S3_CREDENTIALS)
 app = Flask(__name__)
 
 
-@app.route("/<service_id>", methods=["GET", "DELETE"])
-def s3_file(service_id):
+@app.route("/<service_id>", methods=["GET"])
+def get_file(service_id):
     """
     Get or Delete file from s3 interface
     """
@@ -32,20 +32,10 @@ def s3_file(service_id):
     file_name = args.get("file")
 
     try:
-        if request.method == "GET":
-            tmp = tempfile.NamedTemporaryFile()
-            image = s3_interface.get_file(s3_client, bucket, file_name, tmp)
-            return send_file(image, mimetype=mimetypes.guess_type(file_name)[0])
-        else:
-            s3_interface.delete_file(s3_client, bucket, file_name)
-            return (
-                jsonify(
-                    {
-                        "success": "True",
-                    }
-                ),
-                200,
-            )
+        tmp = tempfile.NamedTemporaryFile()
+        image = s3_interface.get_file(s3_client, bucket, file_name, tmp)
+        return send_file(image, mimetype=mimetypes.guess_type(file_name)[0])
+
     except FileNotFoundError:
         return (
             jsonify(
@@ -55,6 +45,34 @@ def s3_file(service_id):
             ),
             404,
         )
+
+
+@app.route("/<service_id>", methods=["DELETE"])
+def delete_file(service_id):
+    if not service_id in settings.S3_CREDENTIALS:
+        return (
+            jsonify(
+                {
+                    "error": "S3 Service not Found",
+                }
+            ),
+            404,
+        )
+
+    bucket = settings.S3_CREDENTIALS[service_id]["bucket"]
+    s3_client = s3_clients[service_id]
+
+    args = request.args
+    file_name = args.get("file")
+    s3_interface.delete_file(s3_client, bucket, file_name)
+    return (
+        jsonify(
+            {
+                "success": "True",
+            }
+        ),
+        200,
+    )
 
 
 if __name__ == "__main__":

--- a/s3/main.py
+++ b/s3/main.py
@@ -9,10 +9,10 @@ s3_clients = s3_interface.get_clients(settings.S3_CREDENTIALS)
 app = Flask(__name__)
 
 
-@app.route("/get/<service_id>/", methods=["GET"])
-def get_file(service_id):
+@app.route("/<service_id>/", methods=["GET", "DELETE"])
+def s3_file(service_id):
     """
-    Get file from s3 interface
+    Get or Delete file from s3 interface
     """
 
     if not service_id in settings.S3_CREDENTIALS:
@@ -31,9 +31,21 @@ def get_file(service_id):
     args = request.args
     file_name = args.get("file")
 
-    tmp = tempfile.NamedTemporaryFile()
     try:
-        image = s3_interface.get_file(s3_client, file_name, bucket, tmp)
+        if request.method == "GET":
+            tmp = tempfile.NamedTemporaryFile()
+            image = s3_interface.get_file(s3_client, bucket, file_name, tmp)
+            return send_file(image, mimetype=mimetypes.guess_type(file_name)[0])
+        else:
+            s3_interface.delete_file(s3_client, bucket, file_name)
+            return (
+                jsonify(
+                    {
+                        "success": "True",
+                    }
+                ),
+                200,
+            )
     except FileNotFoundError:
         return (
             jsonify(
@@ -43,8 +55,6 @@ def get_file(service_id):
             ),
             404,
         )
-    else:
-        return send_file(image, mimetype=mimetypes.guess_type(file_name)[0])
 
 
 if __name__ == "__main__":

--- a/s3/main.py
+++ b/s3/main.py
@@ -9,7 +9,7 @@ s3_clients = s3_interface.get_clients(settings.S3_CREDENTIALS)
 app = Flask(__name__)
 
 
-@app.route("/<service_id>/", methods=["GET", "DELETE"])
+@app.route("/<service_id>", methods=["GET", "DELETE"])
 def s3_file(service_id):
     """
     Get or Delete file from s3 interface

--- a/s3/s3_interface.py
+++ b/s3/s3_interface.py
@@ -17,7 +17,7 @@ def get_clients(s3_credentials):
     return s3_clients
 
 
-def get_file(s3_client, key, bucket, tmp):
+def get_file(s3_client, bucket, key, tmp):
     """
     return specific file in base64 format from bucket to be stored in temp local file
     """
@@ -30,3 +30,10 @@ def get_file(s3_client, key, bucket, tmp):
         raise FileNotFoundError
 
     return tmp.name
+
+
+def delete_file(s3_client, bucket, key):
+    """
+    deletes specific file
+    """
+    return s3_client.delete_object(Bucket=bucket, Key=key)

--- a/s3/tests/conftest.py
+++ b/s3/tests/conftest.py
@@ -5,7 +5,7 @@ from moto import mock_s3
 
 
 @pytest.fixture
-def s3_resource():
+def s3_client():
     with mock_s3():
         s3 = boto3.client(
             "s3",
@@ -14,3 +14,16 @@ def s3_resource():
             region_name="us-east-1",
         )
         yield s3
+
+
+@pytest.fixture
+def bucket_name():
+    return "my-test-bucket"
+
+
+@pytest.fixture
+def s3_test(s3_client, bucket_name):
+    s3_client.create_bucket(Bucket=bucket_name)
+    s3_client.upload_file(
+        Filename="./s3/tests/images/penguin.jpg", Bucket=bucket_name, Key="penguin.jpg"
+    )

--- a/s3/tests/test_delete.py
+++ b/s3/tests/test_delete.py
@@ -1,0 +1,23 @@
+import pytest
+import base64
+import tempfile
+
+from s3 import s3_interface
+
+
+def test_delete_image_pass(s3_client, s3_test, bucket_name):
+    tmp = tempfile.NamedTemporaryFile()
+
+    res = s3_interface.get_file(s3_client, bucket_name, "penguin.jpg", tmp)
+
+    with open(res, "rb") as img:
+        b64_new = base64.b64encode(img.read()).decode("utf-8")
+
+    assert b64_new
+
+    s3_interface.delete_file(s3_client, bucket_name, "penguin.jpg")
+    try:
+        res = s3_interface.get_file(s3_client, bucket_name, "penguin.jpg", tmp)
+        assert False
+    except FileNotFoundError:
+        assert True

--- a/s3/tests/test_get.py
+++ b/s3/tests/test_get.py
@@ -5,23 +5,10 @@ import tempfile
 from s3 import s3_interface
 
 
-@pytest.fixture
-def bucket_name():
-    return "my-test-bucket"
-
-
-@pytest.fixture
-def s3_test(s3_resource, bucket_name):
-    s3_resource.create_bucket(Bucket=bucket_name)
-    s3_resource.upload_file(
-        Filename="./s3/tests/images/penguin.jpg", Bucket=bucket_name, Key="penguin.jpg"
-    )
-
-
-def test_get_image_pass(s3_resource, s3_test, bucket_name):
+def test_get_image_pass(s3_client, s3_test, bucket_name):
     tmp = tempfile.NamedTemporaryFile()
 
-    res = s3_interface.get_file(s3_resource, "penguin.jpg", bucket_name, tmp)
+    res = s3_interface.get_file(s3_client, bucket_name, "penguin.jpg", tmp)
 
     with open("./s3/tests/images/penguin.jpg", "rb") as img:
         b64_og = base64.b64encode(img.read()).decode("utf-8")
@@ -32,11 +19,10 @@ def test_get_image_pass(s3_resource, s3_test, bucket_name):
     assert b64_og == b64_new
 
 
-def test_get_image_not_found(s3_resource, s3_test, bucket_name):
+def test_get_image_not_found(s3_client, s3_test, bucket_name):
     tmp = tempfile.NamedTemporaryFile()
     try:
-        s3_interface.get_file(s3_resource, "does_not_exist", bucket_name, tmp)
+        s3_interface.get_file(s3_client, bucket_name, "does_not_exist", tmp)
+        assert False
     except FileNotFoundError:
         assert True
-    else:
-        assert False


### PR DESCRIPTION
This PR includes an update to the only endpoint:
- now only accepts requests at `/<service_id>` for both `GET` and `DELETE`
- New `DELETE` allows for deletion of file sent as query parameter

Note: boto3 s3 client file deletion does not fail if the file does not exist. Therefore a `DELETE` request at the service will always return success.