### PR TITLE
Change with to env

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -35,6 +35,6 @@ jobs:
         run: cf push --vars-file vars.yaml
           --var ENVIRONMENT_NAME=${{ steps.cf-setup.outputs.target-environment }}
           --strategy rolling
-        with:
+        env:
           SERVICE_1: ${{ secrets.SERVICE_1 }}
           SERVICE_2: ${{ secrets.SERVICE_2 }}


### PR DESCRIPTION
`with` breaks workflow - needs to be `env` to actually work. `with` is used to set inputs, not env variables.