### PR TITLE
Move env variables to deploy line

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -33,8 +33,5 @@ jobs:
 
       - name: Deploy application
         run: cf push --vars-file vars.yaml
-          --var ENVIRONMENT_NAME=${{ steps.cf-setup.outputs.target-environment }}
+          --var ENVIRONMENT_NAME=${{ steps.cf-setup.outputs.target-environment }} --var SERVICE_1=${{ secrets.SERVICE_1 }} --var SERVICE_2=${{ secrets.SERVICE_2 }}
           --strategy rolling
-        env:
-          SERVICE_1: ${{ secrets.SERVICE_1 }}
-          SERVICE_2: ${{ secrets.SERVICE_2 }}


### PR DESCRIPTION
Environment variables weren't getting picked up by the cf deploy command. Moving them to the command allows for the deployment to run.